### PR TITLE
Update rutorrent.yml

### DIFF
--- a/apps/rutorrent.yml
+++ b/apps/rutorrent.yml
@@ -19,6 +19,8 @@
         extport2: "5000"
         intport3: "51413"
         extport3: "51413"
+        intport4: "6881/udp"
+        extport4: "6881"
         image: "linuxserver/rutorrent"
 
     # CORE (MANDATORY) ############################################################
@@ -77,7 +79,7 @@
           - "{{ports.stdout}}{{extport}}:{{intport}}"
           - "{{ports.stdout}}{{extport2}}:{{intport2}}"
           - "{{ports.stdout}}{{extport3}}:{{intport3}}"
-          - "{{extport4}}:{{intport4}}"
+          - "{{ports.stdout}}{{extport4}}:{{intport4}}"
         volumes: "{{pg_volumes}}"
         env: "{{pg_env}}"
         restart_policy: unless-stopped


### PR DESCRIPTION
Attempting to fix the following during rutorrent deployment: 

TASK [Deploying rutorrent] *****************************************************
Thursday 28 February 2019  19:43:51 -0600 (0:00:00.022)       0:00:07.336 ***** 
fatal: [127.0.0.1]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'extport4' is undefined\n\nThe error appears to have been in '/opt/coreapps/apps/rutorrent.yml': line 71, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    # MAIN DEPLOYMENT #############################################################\n    - name: \"Deploying {{pgrole}}\"\n      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
	to retry, use: --limit @/opt/coreapps/apps/rutorrent.retry